### PR TITLE
Disallow python-docx 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     install_requires=[
         'Django >= 3.2.18',
         'python-pptx >= 0.6.21',
-        'python-docx >= 0.8.11',
+        'python-docx >= 0.8.11, != 1.0.0',
         'openpyxl >= 3.0.7',
         'PyYAML >= 6.0'
     ],


### PR DESCRIPTION
Refs https://github.com/python-openxml/python-docx/issues/1256

See CI [failure](https://github.com/archesproject/arches-for-science/actions/runs/6477658563/job/17588192353?pr=1271) in AfS

Maintainer forecasts the original export being restored in 1.0.1.