### PR TITLE
Prep release 0.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ENV/
 arches_templating.egg-info
+build/
 __pycache__

--- a/arches_templating/__init__.py
+++ b/arches_templating/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__package__)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '0.1.1'
+version = '0.1.2'
 
 setup(
     name="arches-templating",


### PR DESCRIPTION
Update version to 0.1.2 and allow user to see version using `arches_templating.__version__`